### PR TITLE
avoid leaving http request connections open

### DIFF
--- a/client.js
+++ b/client.js
@@ -148,30 +148,33 @@ var makeCall = function(done, req_id){
     var start = new Date().getTime();
 
     http_get(target, function(res) {
-        var client_time = new Date().getTime() - start;
-        var status = res.statusCode;
+        res.on('data', function(){/*Do nothing. Consume data so the connection ends.*/});
+        res.on('end', function(){
+            var client_time = new Date().getTime() - start;
+            var status = res.statusCode;
 
-        // show server-compute time if server reports it
-        function get_server_time(res){
-            if(res.headers["x-response-time"]) return res.headers["x-response-time"];
-            if(res.headers["x-runtime"]) return Math.floor(res.headers["x-runtime"]*1000);
-            return -1;
-        }
-        var server_time = get_server_time(res);
+            // show server-compute time if server reports it
+            function get_server_time(res){
+                if(res.headers["x-response-time"]) return res.headers["x-response-time"];
+                if(res.headers["x-runtime"]) return Math.floor(res.headers["x-runtime"]*1000);
+                return -1;
+            }
+            var server_time = get_server_time(res);
 
-        //console.error(util.inspect(res.headers));
+            //console.error(util.inspect(res.headers));
 
-        var r = {
-            status: status,
-            request_id: req_id,
-            response_count: response_count++,
-            client_time: client_time,
-            server_time: server_time
-        };
+            var r = {
+                status: status,
+                request_id: req_id,
+                response_count: response_count++,
+                client_time: client_time,
+                server_time: server_time
+            };
 
-        log_request(r);
+            log_request(r);
 
-        done(client_time, status);
+            done(client_time, status);
+        });
     }).on('error', function(e) {
         var time = new Date().getTime() - start;
         console.log("Got error: " + e.message);


### PR DESCRIPTION
Since the request is not consuming the data, the http request connection is left open. 

Check http://nodejs.org/docs/latest/api/http.html#http_class_http_agent, and the config value "agent.maxSockets"

"By default set to 5. Determines how many concurrent sockets the agent can have open per host."

What happens is that being all those connections open, there's a moment when no more requests will be made and the application just hangs. You could just change the maxSockets value, but that's not the real solution.

By listening to the "data" event, we allow the connection to finish. I also moved all the timing logic inside the "end" event.
